### PR TITLE
Run python TAFKAP on non-simulated data

### DIFF
--- a/TAFKAP.py
+++ b/TAFKAP.py
@@ -249,6 +249,7 @@ def TAFKAP_decode(samples=None, p={}):
     'precision': 'double'
     }
     
+    # set default parameters
     p = setdefaults(defaults, p)   
     
     if samples is None:
@@ -256,8 +257,9 @@ def TAFKAP_decode(samples=None, p={}):
         Ntraintrials = 200
         Ntesttrials = 20
         Ntrials = Ntraintrials+Ntesttrials
-        nclasses = 4 #Only relevant when simulating categorical stimuli
-        
+        nclasses = 4 # Only relevant when simulating categorical stimuli
+
+        # simulating data
         samples, sp = makeSNCData({
             'nvox': 500, 
             'ntrials': Ntrials, 
@@ -269,17 +271,21 @@ def TAFKAP_decode(samples=None, p={}):
             'shuffle_oris': 1,
             'sim_stim_type': p['stim_type'],
             'nclasses': nclasses        
-        })    
+        })
+
+        # set parameters with simulation parameters
+        p["Ntraintrials"] = Ntraintrials
+        p['stimval'] = sp['stimval']
+        p['runNs'] = sp['run_idx']
+
         
     Ntrials = samples.shape[0]
-    p['train_trials'] = np.arange(0,Ntrials) < Ntraintrials
+    p['train_trials'] = np.arange(0,Ntrials) < p["Ntraintrials"]
     p['test_trials'] = np.logical_not(p['train_trials'])
 
-    p['stimval'] = sp['stimval']
-    if p['stim_type']=='circular': p['stimval'] /= (pi/90)
-    p['runNs'] = sp['run_idx']    
+    if p['stim_type'] == 'circular': p['stimval'] /= (pi/90)
 
-    assert 'stimval' in p and 'train_trials' in p and 'test_trials' in p and 'runNs' in p, 'Must specify stimval, train_trials, test_trials and runNs'
+    assert 'stimval' in p and 'runNs' in p, 'Must specify stimval and runNs'
 
     np.random.seed(p['randseed'])
     random.seed(p['randseed'])

--- a/TAFKAP.py
+++ b/TAFKAP.py
@@ -278,12 +278,17 @@ def TAFKAP_decode(samples=None, p={}):
         p['stimval'] = sp['stimval']
         p['runNs'] = sp['run_idx']
 
-        
+    # get number of trials
     Ntrials = samples.shape[0]
+
+    # create test and train data indices
+    assert "Ntraintrials" in p, "Must specify Ntraintrials in parameters"
     p['train_trials'] = np.arange(0,Ntrials) < p["Ntraintrials"]
     p['test_trials'] = np.logical_not(p['train_trials'])
 
-    if p['stim_type'] == 'circular': p['stimval'] /= (pi/90)
+    # transform circular stimulus values to radians
+    if p['stim_type'] == 'circular':
+        p['stimval'] /= (pi/90)
 
     assert 'stimval' in p and 'runNs' in p, 'Must specify stimval and runNs'
 


### PR DESCRIPTION
Hello everybody,

I was trying to run the TAFKAP model on my custom simulated data (so not generated within the TAFKAP function) and it could not run.
As you can see in line 278 and 280, the function parses the sp parameters from simulating data into the dictionary p, but without simulation sp does not exist. Therefore I put it into the if clause, which also removes the necessity to assert the existence of 'train_trials' and 'test_trials' in p, because they are always define in ll. 286 and 287.

But I also added a check for Ntraintrials in p, because this seems necessary and provides clearer feedback to the user if it was not included.

With these changes the model is running on externally created data. So if you think these changes might be worthwhile, I'd be happy to hear from you!